### PR TITLE
Some very minor case adjustments and esm1.6 change

### DIFF
--- a/documentation/docs/pages/index.md
+++ b/documentation/docs/pages/index.md
@@ -1,10 +1,10 @@
 
 # Home
 
-Welcome to the documentation for the [ACCESS-cm3 model configurations](https://github.com/ACCESS-NRI/access-cm3-configs)! 
+Welcome to the documentation for the [ACCESS-CM3 model configurations](https://github.com/ACCESS-NRI/access-cm3-configs)! 
 
 
-## ACCESS-cm3 Documentation Overview
+## ACCESS-CM3 Documentation Overview
 
 See the navigation links on the left. Some reading tips, see:
 
@@ -13,8 +13,8 @@ See the navigation links on the left. Some reading tips, see:
  - [Configuration choices/Configurations](/configurations/Overview/) 
  - [Infrastructure](/infrastructure/Architecture/) 
 
-## access-ems1.6-configs Overview
-ACCESS-cm3 configurations are provided via branches in the [access-cm3-configs](https://github.com/ACCESS-NRI/access-cm3-configs) GitHub repository, this repository is currently private. The [access-cm3-configs](https://github.com/ACCESS-NRI/access-cm3-configs) repository contains several configurations using the following components:
+## access-cm3-configs Overview
+ACCESS-CM3 configurations are provided via branches in the [access-cm3-configs](https://github.com/ACCESS-NRI/access-cm3-configs) GitHub repository, this repository is currently private. The [access-cm3-configs](https://github.com/ACCESS-NRI/access-cm3-configs) repository contains several configurations using the following components:
 
 - [MOM5](https://github.com/ACCESS-NRI/mom5) ocean model
 - [UM](https://github.com/ACCESS-NRI/UM) atmosphere model


### PR DESCRIPTION
A couple of instances of standalone "ACCESS-CM3" weren't capitalised on the top level `index`, and there was 1 mention of ESM1.6.